### PR TITLE
Fixes line break issue for Moodle 3.9.x

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,12 @@
+.que.multichoicewiris .answer div.r0,
+.que.multichoicewiris .answer div.r1 {
+    display: flex;
+    margin: 0.25rem 0;
+    align-items: flex-start;
+}
+
+.que.multichoicewiris .answer div.r0 input,
+.que.multichoicewiris .answer div.r1 input {
+    margin: 0.3rem 0.5rem;
+    width: 14px;
+}


### PR DESCRIPTION
We installed qtype_multichoicewiris on a Moodle 3.9.1 (Build: 20200713) (even though this plugin is not approved for that, I know). And it seems like there is a weird line break issue for simple multi choice questions. 
That comes from the fact that the code of the `multichoice` renderer is reused but the actual css isn't. Would be really cool if Moodle would allow an automatic reuse of that CSS code by just adding the `multichoice` class to the `div` with the `multichoicewiris` class. But unfortunatel, that's not the case. So here we go. I copy pasted the necessary css rules.